### PR TITLE
Remembering User's Book Sort Preference

### DIFF
--- a/frontend/src/components/books/Books.tsx
+++ b/frontend/src/components/books/Books.tsx
@@ -10,9 +10,21 @@ import styles from "./css/Books.module.scss";
 function Books() {
   const [books, setBooks] = useState<BookWithBookshelvesInterface[]>([]);
   const [search, setSearch] = useState<string | null>(null);
-  const [sort, setSort] = useState<string>("id");
-  const [sortDirection, setSortDirection] = useState<string>("ascending");
+  const [sort, setSort] = useState<string>(
+    () => localStorage.getItem("sort") || "id"
+  );
+  const [sortDirection, setSortDirection] = useState<string>(
+    () => localStorage.getItem("sortDirection") || "ascending"
+  );
   const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    localStorage.setItem("sort", sort);
+  }, [sort]);
+
+  useEffect(() => {
+    localStorage.setItem("sortDirection", sortDirection);
+  }, [sortDirection]);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -74,10 +86,9 @@ function Books() {
               id="floatingSelect"
               aria-label="Floating label select example"
               onChange={handleSort}
+              value={sort}
             >
-              <option value="id" selected>
-                Date Added
-              </option>
+              <option value="id">Date Added</option>
               <option value="title">Title</option>
               <option value="author">Author</option>
               <option value="year">Year</option>


### PR DESCRIPTION
Previously, when a user selected a 'sort' preference on the main /books page, that sort was honored only until the user navigated away or closed the tab. It was not remembered.

One option was to persist this value to the backend of the application and into the database, similar to how we've persisted the sort preference for a bookshelf. However, this would have necessitated creating a new table (user preferences?) and new routes, interfaces, etc. 

This seemed overkill for this one preference, so instead we use Local Storage on the front end to store the simple key->value pairs. If in the future there are more preferences, we can re-visit persisting to the backend.

Closes #61