### PR TITLE
Sort by Author Surname and Dates Read

### DIFF
--- a/frontend/src/components/books/Books.tsx
+++ b/frontend/src/components/books/Books.tsx
@@ -4,7 +4,10 @@ import Col from "react-bootstrap/Col";
 import Container from "react-bootstrap/Container";
 import Book from "./Book";
 import { GetBooks } from "../../services/books";
-import { BookWithBookshelvesInterface } from "../../interfaces/book_and_bookshelf";
+import {
+  BookWithBookshelvesInterface,
+  SortableBookProperties,
+} from "../../interfaces/book_and_bookshelf";
 import styles from "./css/Books.module.scss";
 
 function Books() {
@@ -17,6 +20,10 @@ function Books() {
     () => localStorage.getItem("sortDirection") || "ascending"
   );
   const [loading, setLoading] = useState(true);
+  type SortFunction<T> = {
+    (value: T, book: BookWithBookshelvesInterface): string | Date | null;
+    (value: T): string | Date | null;
+  };
 
   useEffect(() => {
     localStorage.setItem("sort", sort);
@@ -59,6 +66,97 @@ function Books() {
     );
   };
 
+  const surnameSort: SortFunction<string> = (author_name: string) => {
+    /* 
+    There may be a more intelligent way of handling this, such as procuring
+    proper, semantic `first` and `last` names for each Author. In lieu of
+    that, we attempt to determine whether or not their `double-barrelled` surname
+    should be preserved for sorting.
+    Example:
+    Ursula K. Le Guin should be sorted by L, not G
+    Guy de Maupassant should be sorted by M, not D
+    */
+
+    const nameParts = author_name.split(" ");
+
+    // List of integral prefixes (part of surname)
+    const integralPrefixes = ["le", "la", "de la"];
+
+    // List of common surname prefixes to ignore
+    const ignorePrefixes = [
+      "van",
+      "von",
+      "de",
+      "del",
+      "di",
+      "da",
+      "al",
+      "bin",
+      "mc",
+      "mac",
+      "ibn",
+    ];
+
+    // Start by assuming the last name is the surname
+    let surname = nameParts[nameParts.length - 1];
+
+    // Check if the name includes an integral prefix
+    for (let i = nameParts.length - 1; i > 0; i--) {
+      const potentialPrefix = nameParts[i - 1].toLowerCase();
+      const fullSurnameCandidate = nameParts.slice(i - 1).join(" ");
+
+      // If the prefix is part of the surname (e.g., "Le Guin")
+      if (integralPrefixes.includes(potentialPrefix)) {
+        surname = fullSurnameCandidate;
+        break;
+      }
+
+      // If we find an ignorable prefix, we stop and return the next part as surname
+      else if (ignorePrefixes.includes(potentialPrefix)) {
+        surname = nameParts[i];
+        break;
+      }
+    }
+
+    return surname.toLowerCase();
+  };
+
+  const dateSort: SortFunction<string> = (
+    read_end_date_string: string | null,
+    book?: BookWithBookshelvesInterface
+  ) => {
+    if (book === undefined) {
+      console.log("Can't sort by date as book is undefined");
+      return null;
+    }
+    // If there is a start date, but no end date, the end
+    // should be "today" for proper sorting
+    if (!read_end_date_string) {
+      if (book.read_start_date) {
+        return new Date();
+      }
+      return null;
+    }
+    return new Date(read_end_date_string);
+  };
+
+  const sortFunctions: Record<string, SortFunction<any>> = {
+    author: surnameSort as SortFunction<string>,
+    read_end_date: dateSort as SortFunction<string>,
+  };
+
+  const mapValueToSortable = (
+    key: string,
+    value: string | number | null,
+    book: BookWithBookshelvesInterface
+  ) => {
+    // We've defined no specific sorting function for the value
+    if (!(key in sortFunctions)) {
+      return value;
+    }
+    return sortFunctions[key](value, book);
+  };
+
   if (loading) {
     return <div>Loading...</div>;
   }
@@ -93,6 +191,7 @@ function Books() {
               <option value="author">Author</option>
               <option value="year">Year</option>
               <option value="rating">Rating</option>
+              <option value="read_end_date">Reading Dates</option>
             </select>
             <label htmlFor="floatingSelect">Sort by</label>
           </div>
@@ -143,30 +242,43 @@ function Books() {
               bookA: BookWithBookshelvesInterface,
               bookB: BookWithBookshelvesInterface
             ) => {
-              const sortKey = sort as keyof BookWithBookshelvesInterface;
+              const sortKey = sort as keyof SortableBookProperties;
               const directionModifier = sortDirection === "ascending" ? 1 : -1;
               if (
-                !bookA ||
-                !bookB ||
                 bookA[sortKey] === undefined ||
                 bookB[sortKey] === undefined
               ) {
                 return 0;
               }
+              // If the value is null, we essentially remove it from the
+              // order by placing it at the very end with either 0 or Infinity
+              // depending on sort direction
               let nullPosition = Infinity;
               if (directionModifier === -1) {
                 nullPosition = 0;
               }
-              const bookAComparison =
-                bookA[sortKey] !== null ? bookA[sortKey] : nullPosition;
-              const bookBComparison =
-                bookB[sortKey] !== null ? bookB[sortKey] : nullPosition;
+              const bookAMappedValue = mapValueToSortable(
+                sortKey,
+                bookA[sortKey],
+                bookA
+              );
+              const bookAComparison = bookAMappedValue
+                ? bookAMappedValue
+                : nullPosition;
+              const bookBMappedValue = mapValueToSortable(
+                sortKey,
+                bookB[sortKey],
+                bookB
+              );
+              const bookBComparison = bookBMappedValue
+                ? bookBMappedValue
+                : nullPosition;
               if (bookAComparison < bookBComparison) {
                 return -1 * directionModifier;
               } else if (bookAComparison > bookBComparison) {
                 return 1 * directionModifier;
               }
-              // a must be equal to b
+              // A and B are equal
               return 0;
             }
           )

--- a/frontend/src/components/books/Books.tsx
+++ b/frontend/src/components/books/Books.tsx
@@ -8,6 +8,7 @@ import {
   BookWithBookshelvesInterface,
   SortableBookProperties,
 } from "../../interfaces/book_and_bookshelf";
+import { bookSort } from "../../utils/book_sort";
 import styles from "./css/Books.module.scss";
 
 function Books() {
@@ -20,10 +21,6 @@ function Books() {
     () => localStorage.getItem("sortDirection") || "ascending"
   );
   const [loading, setLoading] = useState(true);
-  type SortFunction<T> = {
-    (value: T, book: BookWithBookshelvesInterface): string | Date | null;
-    (value: T): string | Date | null;
-  };
 
   useEffect(() => {
     localStorage.setItem("sort", sort);
@@ -64,97 +61,6 @@ function Books() {
     setSortDirection(
       sortDirection === "ascending" ? "descending" : "ascending"
     );
-  };
-
-  const surnameSort: SortFunction<string> = (author_name: string) => {
-    /* 
-    There may be a more intelligent way of handling this, such as procuring
-    proper, semantic `first` and `last` names for each Author. In lieu of
-    that, we attempt to determine whether or not their `double-barrelled` surname
-    should be preserved for sorting.
-    Example:
-    Ursula K. Le Guin should be sorted by L, not G
-    Guy de Maupassant should be sorted by M, not D
-    */
-
-    const nameParts = author_name.split(" ");
-
-    // List of integral prefixes (part of surname)
-    const integralPrefixes = ["le", "la", "de la"];
-
-    // List of common surname prefixes to ignore
-    const ignorePrefixes = [
-      "van",
-      "von",
-      "de",
-      "del",
-      "di",
-      "da",
-      "al",
-      "bin",
-      "mc",
-      "mac",
-      "ibn",
-    ];
-
-    // Start by assuming the last name is the surname
-    let surname = nameParts[nameParts.length - 1];
-
-    // Check if the name includes an integral prefix
-    for (let i = nameParts.length - 1; i > 0; i--) {
-      const potentialPrefix = nameParts[i - 1].toLowerCase();
-      const fullSurnameCandidate = nameParts.slice(i - 1).join(" ");
-
-      // If the prefix is part of the surname (e.g., "Le Guin")
-      if (integralPrefixes.includes(potentialPrefix)) {
-        surname = fullSurnameCandidate;
-        break;
-      }
-
-      // If we find an ignorable prefix, we stop and return the next part as surname
-      else if (ignorePrefixes.includes(potentialPrefix)) {
-        surname = nameParts[i];
-        break;
-      }
-    }
-
-    return surname.toLowerCase();
-  };
-
-  const dateSort: SortFunction<string> = (
-    read_end_date_string: string | null,
-    book?: BookWithBookshelvesInterface
-  ) => {
-    if (book === undefined) {
-      console.log("Can't sort by date as book is undefined");
-      return null;
-    }
-    // If there is a start date, but no end date, the end
-    // should be "today" for proper sorting
-    if (!read_end_date_string) {
-      if (book.read_start_date) {
-        return new Date();
-      }
-      return null;
-    }
-    return new Date(read_end_date_string);
-  };
-
-  const sortFunctions: Record<string, SortFunction<any>> = {
-    author: surnameSort as SortFunction<string>,
-    read_end_date: dateSort as SortFunction<string>,
-  };
-
-  const mapValueToSortable = (
-    key: string,
-    value: string | number | null,
-    book: BookWithBookshelvesInterface
-  ) => {
-    // We've defined no specific sorting function for the value
-    if (!(key in sortFunctions)) {
-      return value;
-    }
-    return sortFunctions[key](value, book);
   };
 
   if (loading) {
@@ -242,44 +148,12 @@ function Books() {
               bookA: BookWithBookshelvesInterface,
               bookB: BookWithBookshelvesInterface
             ) => {
-              const sortKey = sort as keyof SortableBookProperties;
-              const directionModifier = sortDirection === "ascending" ? 1 : -1;
-              if (
-                bookA[sortKey] === undefined ||
-                bookB[sortKey] === undefined
-              ) {
-                return 0;
-              }
-              // If the value is null, we essentially remove it from the
-              // order by placing it at the very end with either 0 or Infinity
-              // depending on sort direction
-              let nullPosition = Infinity;
-              if (directionModifier === -1) {
-                nullPosition = 0;
-              }
-              const bookAMappedValue = mapValueToSortable(
-                sortKey,
-                bookA[sortKey],
-                bookA
+              return bookSort(
+                bookA,
+                bookB,
+                sort as keyof SortableBookProperties,
+                sortDirection
               );
-              const bookAComparison = bookAMappedValue
-                ? bookAMappedValue
-                : nullPosition;
-              const bookBMappedValue = mapValueToSortable(
-                sortKey,
-                bookB[sortKey],
-                bookB
-              );
-              const bookBComparison = bookBMappedValue
-                ? bookBMappedValue
-                : nullPosition;
-              if (bookAComparison < bookBComparison) {
-                return -1 * directionModifier;
-              } else if (bookAComparison > bookBComparison) {
-                return 1 * directionModifier;
-              }
-              // A and B are equal
-              return 0;
             }
           )
           .map((book: BookWithBookshelvesInterface) => (

--- a/frontend/src/components/bookshelves/Bookshelf.tsx
+++ b/frontend/src/components/bookshelves/Bookshelf.tsx
@@ -17,7 +17,9 @@ import LazyImage from "../common/LazyLoadImage";
 import {
   BookInterface,
   BookshelfWithBooksInterface,
+  SortableBookProperties,
 } from "../../interfaces/book_and_bookshelf";
+import { bookSort } from "../../utils/book_sort";
 import styles from "./css/Bookshelf.module.scss";
 
 interface BookshelfProps {
@@ -344,27 +346,12 @@ function Bookshelf({ bookshelfId, preview }: BookshelfProps) {
         {bookshelf &&
           bookshelf.books
             .sort((bookA: BookInterface, bookB: BookInterface) => {
-              const localSortKey = sortKey as keyof BookInterface;
-              const directionModifier = sortDirection === "ascending" ? 1 : -1;
-              let nullPosition = Infinity;
-              if (directionModifier === -1) {
-                nullPosition = 0;
-              }
-              const bookAComparison =
-                bookA[localSortKey] !== null
-                  ? bookA[localSortKey]
-                  : nullPosition;
-              const bookBComparison =
-                bookB[localSortKey] !== null
-                  ? bookB[localSortKey]
-                  : nullPosition;
-              if (bookAComparison < bookBComparison) {
-                return -1 * directionModifier;
-              } else if (bookAComparison > bookBComparison) {
-                return 1 * directionModifier;
-              }
-              // a must be equal to b
-              return 0;
+              return bookSort(
+                bookA,
+                bookB,
+                sortKey as keyof SortableBookProperties,
+                sortDirection
+              );
             })
             .map((book: BookInterface) => (
               <Col

--- a/frontend/src/interfaces/book_and_bookshelf.d.ts
+++ b/frontend/src/interfaces/book_and_bookshelf.d.ts
@@ -9,12 +9,21 @@ export interface BookInterface {
   rating: number | null;
   review: string;
   read_status: string;
-  read_start_date: string;
-  read_end_date: string;
+  read_start_date: string | null;
+  read_end_date: string | null;
 }
 
 export interface BookWithBookshelvesInterface extends BookInterface {
   bookshelves?: BookshelfInterface[];
+}
+
+export interface SortableBookProperties {
+  id: number;
+  title: string;
+  author: string;
+  year: number;
+  rating: number | null;
+  read_end_date: string | null;
 }
 
 export interface CreateOrUpdateBookInterface {

--- a/frontend/src/utils/book_sort.ts
+++ b/frontend/src/utils/book_sort.ts
@@ -1,0 +1,130 @@
+import {
+  BookWithBookshelvesInterface,
+  SortableBookProperties,
+} from "../interfaces/book_and_bookshelf";
+
+type SortFunction<T> = {
+  (value: T, book: BookWithBookshelvesInterface): string | Date | null;
+  (value: T): string | Date | null;
+};
+
+const surnameSort: SortFunction<string> = (author_name: string) => {
+  /* 
+  There may be a more intelligent way of handling this, such as procuring
+  proper, semantic `first` and `last` names for each Author. In lieu of
+  that, we attempt to determine whether or not their `double-barrelled` surname
+  should be preserved for sorting.
+  Example:
+  Ursula K. Le Guin should be sorted by L, not G
+  Guy de Maupassant should be sorted by M, not D
+  */
+
+  const nameParts = author_name.split(" ");
+
+  // List of integral prefixes (part of surname)
+  const integralPrefixes = ["le", "la", "de la"];
+
+  // List of common surname prefixes to ignore
+  const ignorePrefixes = [
+    "van",
+    "von",
+    "de",
+    "del",
+    "di",
+    "da",
+    "al",
+    "bin",
+    "mc",
+    "mac",
+    "ibn",
+  ];
+
+  // Start by assuming the last name is the surname
+  let surname = nameParts[nameParts.length - 1];
+
+  // Check if the name includes an integral prefix
+  for (let i = nameParts.length - 1; i > 0; i--) {
+    const potentialPrefix = nameParts[i - 1].toLowerCase();
+    const fullSurnameCandidate = nameParts.slice(i - 1).join(" ");
+
+    // If the prefix is part of the surname (e.g., "Le Guin")
+    if (integralPrefixes.includes(potentialPrefix)) {
+      surname = fullSurnameCandidate;
+      break;
+    }
+
+    // If we find an ignorable prefix, we stop and return the next part as surname
+    else if (ignorePrefixes.includes(potentialPrefix)) {
+      surname = nameParts[i];
+      break;
+    }
+  }
+
+  return surname.toLowerCase();
+};
+
+const dateSort: SortFunction<string> = (
+  read_end_date_string: string | null,
+  book?: BookWithBookshelvesInterface
+) => {
+  if (book === undefined) {
+    console.log("Can't sort by date as book is undefined");
+    return null;
+  }
+  // If there is a start date, but no end date, the end
+  // should be "today" for proper sorting
+  if (!read_end_date_string) {
+    if (book.read_start_date) {
+      return new Date();
+    }
+    return null;
+  }
+  return new Date(read_end_date_string);
+};
+
+const sortFunctions: Record<string, SortFunction<any>> = {
+  author: surnameSort as SortFunction<string>,
+  read_end_date: dateSort as SortFunction<string>,
+};
+
+const mapValueToSortable = (
+  key: string,
+  value: string | number | null,
+  book: BookWithBookshelvesInterface
+) => {
+  // We've defined no specific sorting function for the value
+  if (!(key in sortFunctions)) {
+    return value;
+  }
+  return sortFunctions[key](value, book);
+};
+
+export const bookSort = (
+  bookA: BookWithBookshelvesInterface,
+  bookB: BookWithBookshelvesInterface,
+  sortKey: keyof SortableBookProperties,
+  sortDirection: string
+) => {
+  const directionModifier = sortDirection === "ascending" ? 1 : -1;
+  if (bookA[sortKey] === undefined || bookB[sortKey] === undefined) {
+    return 0;
+  }
+  // If the value is null, we essentially remove it from the
+  // order by placing it at the very end with either 0 or Infinity
+  // depending on sort direction
+  let nullPosition = Infinity;
+  if (directionModifier === -1) {
+    nullPosition = 0;
+  }
+  const bookAMappedValue = mapValueToSortable(sortKey, bookA[sortKey], bookA);
+  const bookAComparison = bookAMappedValue ? bookAMappedValue : nullPosition;
+  const bookBMappedValue = mapValueToSortable(sortKey, bookB[sortKey], bookB);
+  const bookBComparison = bookBMappedValue ? bookBMappedValue : nullPosition;
+  if (bookAComparison < bookBComparison) {
+    return -1 * directionModifier;
+  } else if (bookAComparison > bookBComparison) {
+    return 1 * directionModifier;
+  }
+  // A and B are equal
+  return 0;
+};


### PR DESCRIPTION
Description is mostly in the commit messages.

Essentially, previously we were sorting by first name by default, which is unexpected behavior for sorting by name.

Switching to last name presented a challenge of actually determining the last name, when there are names like Ursula K. Le Guin, where the last name is 'Le Guin'.

This lead to some hardcoded 'double barelled' surname prefixes to look out for, which of course can be finetuned over time.

There is likely a more mature way to handle this. Chiefly, determining a first and last name semantically and storing in the database as such. Either by using a public API, or having the user determine it.

This seemed like a good stopgap solution however, in that it required no changes to the data structure, nor additional APIs, nor user intervention.

While creating this, I added sorting by 'dates read' which presented its own challenge, due to the fact that we want to handle a book that is in the 'reading' state, meaning having a start date but no end date, a little specially. We determine the 'end date' to be 'today' so as to keep it in line with complete books chronologically.

All sorting logic abstracted to a utility file and imported where needed, currently in both Books and Bookshelf components.

Closes #69 
Closes #72 
