### PR TITLE
Secondary Sort

### DIFF
--- a/frontend/src/components/books/Books.tsx
+++ b/frontend/src/components/books/Books.tsx
@@ -15,7 +15,7 @@ function Books() {
   const [books, setBooks] = useState<BookWithBookshelvesInterface[]>([]);
   const [search, setSearch] = useState<string | null>(null);
   const [sort, setSort] = useState<string>(
-    () => localStorage.getItem("sort") || "id"
+    () => localStorage.getItem("sort") || "title"
   );
   const [sortDirection, setSortDirection] = useState<string>(
     () => localStorage.getItem("sortDirection") || "ascending"


### PR DESCRIPTION
If the result of the primary sort is an equality between two books, such as rating, then we need a secondary sorting mechanism.

This naturally can lead to a chain of requirements like third sort, fourth, so on. It may ultimately become necessary to rank the hierarchy of all sorting options and step through them until an inequality is found, but I think it becomes vanishingly unlikely that there is equality after two rounds.

I think one of the only real, possible scenarios is if there are two books that have the same rating and title. How much of an edge case this is, is unknown.

While doing this, I also added a mapper to avoid common 'articles' like 'the', 'a', 'an' at the start of titles. Typically these are ignored by libraries.

Closes #70 