### PR TITLE
Handling Null Review

### DIFF
--- a/frontend/src/components/books/Book.tsx
+++ b/frontend/src/components/books/Book.tsx
@@ -23,7 +23,7 @@ function Book({ book, preview }: BookProps) {
   const [currentBook, setCurrentBook] =
     useState<BookWithBookshelvesInterface>();
   const [savedCoverUri, setSavedCoverUri] = useState("");
-  const [savedReview, setSavedReview] = useState("");
+  const [savedReview, setSavedReview] = useState<string | null>("");
   const [loading, setLoading] = useState(true);
   const [availableOlids, setAvailableOlids] = useState<string[]>([]);
   const [savedOlid, setSavedOlid] = useState("");
@@ -332,10 +332,14 @@ function Book({ book, preview }: BookProps) {
     const newReview = element.innerHTML;
     // innerHtml will get <div> and <br> elements added by contentenditable <div>
     // swap these for newlines
-    return newReview
+    const cleanedNewReview = newReview
       .replace(/<br\s*\/?>/gi, "\n")
       .replace(/<\/div>|<\/p>/gi, "\n")
       .replace(/<div>|<p>/gi, "");
+    if (cleanedNewReview === "") {
+      return null;
+    }
+    return cleanedNewReview;
   };
 
   const getAuthor = () => {

--- a/frontend/src/interfaces/book_and_bookshelf.d.ts
+++ b/frontend/src/interfaces/book_and_bookshelf.d.ts
@@ -7,7 +7,7 @@ export interface BookInterface {
   cover_uri: string;
   olids: string;
   rating: number | null;
-  review: string;
+  review: string | null;
   read_status: string;
   read_start_date: string | null;
   read_end_date: string | null;
@@ -34,7 +34,7 @@ export interface CreateOrUpdateBookInterface {
   cover_uri: string;
   olids: string;
   rating: number | null;
-  review: string;
+  review: string | null;
   read_status: string;
   read_start_date: string | null;
   read_end_date: string | null;


### PR DESCRIPTION
If a review is an empty string, which the browser treats it as if we've clicked into the contenteditable div, then we should treat that as 'null', since the field is nullable. This allows us to correctly compare a null value from the database, with an 'empty' review on the front end in the DOM, and act accordingly.

Closes #76 