### PR TITLE
Lazy Loading / Infinite Scrolling Books

### DIFF
--- a/frontend/src/components/books/Books.tsx
+++ b/frontend/src/components/books/Books.tsx
@@ -250,7 +250,7 @@ function Books() {
           </button>
         </Col>
       </Row>
-      <Row>
+      <Row style={{ minHeight: "100vh" }}>
         {displayedBooks.map((book: BookWithBookshelvesInterface) => (
           <Col
             xs={12}
@@ -262,8 +262,8 @@ function Books() {
             <Book book={book} preview={true} key={book.id} />
           </Col>
         ))}
-        <div ref={sentinelRef} style={{ height: "1px" }}></div>
       </Row>
+      <div ref={sentinelRef} style={{ height: "1px" }}></div>
     </Container>
   );
 }


### PR DESCRIPTION
The initial goal here was to get the Books page to load a bit quicker, and that meant not rendering EVERY book we had all at once. Granted, I had already configured lazy loading for images, so we had been spared that overhead, but we were still loading a Book component for every book in our database.

What I wanted to do was load a few, then load more as we scrolled.

Initially, I considered some form of pagination where we utilize some offsets and limits against the API, re-configure the backend to support these queries, etc.

But then I thought a little better of it.

1. I didn't want the pagination to impact the various search, sort, and filter options that we have. Each one of these actions would then necessitate another API call, which is additional overhead and latency.
2. Even without the search, sort, and filter, it rubbed me the wrong way to create some (currently arbitrary) cutoff point and say we get 100 books, and then fetch another 100 if we need.

What I figured I would rather do, to simplify the backend calls, and in fact, not change our API calls AT ALL, was to simply continue to fetch all books, and then manage them on the frontend.

I am not sure, at this writing, what a sensible upper limit really would be to handling Book components in the browser on a single page. A thousand? Ten thousand? More? Hard to say without testing.

I'd mostly be concerned about memory usage for the browser tab, latency with sorting, searching, filtering, etc.

But for now, where I have <200 books, it all feels trivial.

Instead of relying on some existing packages for this, which I found to require maybe a bit more re-writing of the actual component JSX than I wanted to, I figured I would sort of roll my own solution. 

It's not actually my own solution of course, I'm still using React and standard JS api calls, chiefly the Intersection Observer to monitor for a 'sentinel' div just underneath the Books. When it comes into view, it triggers us adding more books to the 'visible books'.

It's possible that a package like `react-infinite-scroll-component` could be a good drop-in replacement for this, but I don't think what I've done is overly custom or janky, and it was good to learn a bit about.

The `100vh` style rule on the <Row> that wraps the <Book> components became necessary due to re-rendering.

Meaning, when a re-render would happen, due to searching, sorting, or filtering, the books would temporarily become a new array, and would all be destroyed and re-rendered. At this moment, intermittently, the sentinel div would become visible in the viewport, because it had nothing above it other than empty <div>s, and would thus trigger the loading of additional books. For instance, we'd load 20 initially, and then 20 whenever the sentinel showed up. So sometimes we'd search, sort or filter, and then we'd have 40 books instead of 20, because the sentinel triggered loading 20 on top of the 20 we had. This was also seen occasionally on initial page load.

I'm sure there's a more mature way around this by managing the state, and the nature of the observer (.unobserve()?) more carefully, but my solution to set the min height equal to the viewport is a decent solution for now.

This entire concept can naturally be expanded to other pages as needed. Potentially:

1. Book search results
2. Bookshelves page

For now, not concerning myself with those as they are much smaller result sets. The search results for instance is very occasionally upwards of, say, 100. Bookshelves will grow much more slowly, but could ultimately benefit from it.

That being said, I don't want to feature creep it. I believe it can be somewhat easily abstracted to a utility if needed.

Closes #59 
