### PR TITLE
Bulk Deletion of Books

### DIFF
--- a/backend/app/routers/books.py
+++ b/backend/app/routers/books.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Path, status, HTTPException, Body
+from fastapi import APIRouter, Depends, Path, status, HTTPException
 from typing import Annotated
 from app.models.book import (
     Book,
@@ -83,7 +83,7 @@ async def update_book(
 # This route needs to appear before the one below so `bulk` is not interpreted as a `book_id`
 @router.delete("/bulk", status_code=status.HTTP_204_NO_CONTENT)
 def bulk_delete_book(
-    bulk_delete: BookIds = Body(...),
+    bulk_delete: BookIds,
     db: Session = Depends(get_db)
 ):
     book_ids = bulk_delete.book_ids

--- a/backend/app/routers/books.py
+++ b/backend/app/routers/books.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Path, status, HTTPException
+from fastapi import APIRouter, Depends, Path, status, HTTPException, Body
 from typing import Annotated
 from app.models.book import (
     Book,
@@ -6,6 +6,7 @@ from app.models.book import (
     BookUpdate,
     BookPublic,
     BookPublicWithBookshelves,
+    BookIds
 )
 from app.models.openlibrary import Works
 from app.models.exception import ExceptionHandler
@@ -55,7 +56,7 @@ async def create_book(
 
 
 @router.patch("/{book_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def update_bookshelf(
+async def update_book(
     book_id: Annotated[int, Path(title="The ID of the book to update")],
     book_update: BookUpdate,
     db: Session = Depends(get_db),
@@ -79,8 +80,25 @@ async def update_bookshelf(
     return None
 
 
+# This route needs to appear before the one below so `bulk` is not interpreted as a `book_id`
+@router.delete("/bulk", status_code=status.HTTP_204_NO_CONTENT)
+def bulk_delete_book(
+    bulk_delete: BookIds = Body(...),
+    db: Session = Depends(get_db)
+):
+    book_ids = bulk_delete.book_ids
+    statement = select(Book).where(Book.id.in_(book_ids))
+    books_to_delete = db.exec(statement).all()
+    if not books_to_delete:
+        raise HTTPException(status_code=404, detail="Books not found")
+    for book in books_to_delete:
+        db.delete(book)
+    db.commit()
+    return None
+
+
 @router.delete("/{book_id}", status_code=status.HTTP_204_NO_CONTENT)
-def delete_bookshelf(
+def delete_book(
     book_id: Annotated[int, Path(title="The ID of the book to delete")],
     db: Session = Depends(get_db)
 ):

--- a/backend/app/routers/bookshelves.py
+++ b/backend/app/routers/bookshelves.py
@@ -22,6 +22,7 @@ def get_bookshelves(db: Session = Depends(get_db)):
     return bookshelves
 
 
+# This route needs to appear before the one below so `sort_keys` is not interpreted as a `bookshelf_id`
 @router.get("/sort_keys", status_code=status.HTTP_200_OK, response_model=list[str])
 def get_bookshelf_sort_keys():
     return [key.value for key in SortKey]

--- a/frontend/src/components/books/Book.tsx
+++ b/frontend/src/components/books/Book.tsx
@@ -802,7 +802,7 @@ function Book({ book, preview }: BookProps) {
             Cancel
           </Button>
           <Button
-            variant="primary"
+            variant="danger"
             onClick={handleDelete}
             aria-label="Delete Confirmation"
           >

--- a/frontend/src/components/books/Books.tsx
+++ b/frontend/src/components/books/Books.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
+import Modal from "react-bootstrap/Modal";
+import Button from "react-bootstrap/Button";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import Container from "react-bootstrap/Container";
@@ -36,6 +38,7 @@ function Books() {
   const [selectedBooksForDeletion, setSelectedBooksForDeletion] = useState<
     number[]
   >([]);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
 
   // Function to update filtered books based on search, sort, and filter
   const updateFilteredBooks = () => {
@@ -194,6 +197,7 @@ function Books() {
     );
     setSelectedBooksForDeletion([]);
     setBulkDeleteMode(false);
+    handleCloseDeleteModal();
   };
 
   const toggleBookForDeletion = (bookId: number) => {
@@ -202,6 +206,17 @@ function Books() {
         ? prev.filter((id) => id !== bookId)
         : [...prev, bookId]
     );
+  };
+
+  const handleShowDeleteModal = (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    event.preventDefault();
+    setShowDeleteModal(true);
+  };
+
+  const handleCloseDeleteModal = () => {
+    setShowDeleteModal(false);
   };
 
   if (loading) {
@@ -314,7 +329,7 @@ function Books() {
                 <button
                   type="button"
                   className={`btn btn-sm btn-outline-danger`}
-                  onClick={handleBulkDelete}
+                  onClick={handleShowDeleteModal}
                   aria-label="Bulk Delete"
                 >
                   Delete
@@ -358,6 +373,28 @@ function Books() {
             </Col>
           ))}
         </Row>
+        <Modal show={showDeleteModal} onHide={handleCloseDeleteModal} centered>
+          <Modal.Header closeButton>
+            <Modal.Title>Warning</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>Are you sure you want to delete these books?</Modal.Body>
+          <Modal.Footer>
+            <Button
+              variant="outline-secondary"
+              onClick={handleCloseDeleteModal}
+              aria-label="Cancel Delete"
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="outline-danger"
+              onClick={handleBulkDelete}
+              aria-label="Delete Confirmation"
+            >
+              Delete
+            </Button>
+          </Modal.Footer>
+        </Modal>
       </Container>
       <div ref={sentinelRef} style={{ height: "1px" }}></div>
     </>

--- a/frontend/src/components/books/Books.tsx
+++ b/frontend/src/components/books/Books.tsx
@@ -3,7 +3,7 @@ import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import Container from "react-bootstrap/Container";
 import Book from "./Book";
-import { GetBooks } from "../../services/books";
+import { GetBooks, BulkDeleteBooks } from "../../services/books";
 import {
   BookWithBookshelvesInterface,
   SortableBookProperties,
@@ -32,6 +32,10 @@ function Books() {
   const [loading, setLoading] = useState(true);
   const sentinelRef = useRef<HTMLDivElement | null>(null); // Ref for the sentinel element for IntersectionObserver
   const observerRef = useRef<IntersectionObserver | null>(null); // Ref for IntersectionObserver instance
+  const [bulkDeleteMode, setBulkDeleteMode] = useState(false);
+  const [selectedBooksForDeletion, setSelectedBooksForDeletion] = useState<
+    number[]
+  >([]);
 
   // Function to update filtered books based on search, sort, and filter
   const updateFilteredBooks = () => {
@@ -160,6 +164,46 @@ function Books() {
     };
   }, [hasMore, displayedBooks]);
 
+  const handleBulkDeleteSetup = (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    event.preventDefault();
+    setBulkDeleteMode(true);
+  };
+
+  const handleBulkDeleteCancel = (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    event.preventDefault();
+    setBulkDeleteMode(false);
+    setSelectedBooksForDeletion([]);
+  };
+
+  const handleBulkDelete = async (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    event.preventDefault();
+    const response: boolean = await BulkDeleteBooks(selectedBooksForDeletion);
+    if (!response) {
+      // A message to the user may be warranted here
+      // Especially if we are going to prevent navigation
+      return false;
+    }
+    setAllBooks((prev) =>
+      prev.filter((book) => !selectedBooksForDeletion.includes(book.id))
+    );
+    setSelectedBooksForDeletion([]);
+    setBulkDeleteMode(false);
+  };
+
+  const toggleBookForDeletion = (bookId: number) => {
+    setSelectedBooksForDeletion((prev) =>
+      prev.includes(bookId)
+        ? prev.filter((id) => id !== bookId)
+        : [...prev, bookId]
+    );
+  };
+
   if (loading) {
     return <div>Loading...</div>;
   }
@@ -181,7 +225,7 @@ function Books() {
               <label htmlFor="search">Search...</label>
             </form>
           </Col>
-          <Col xs={4} sm={3}>
+          <Col xs={3} sm={2}>
             <div className={`form-floating ${styles["custom-form-floating"]}`}>
               <select
                 className="form-select"
@@ -198,7 +242,7 @@ function Books() {
               <label htmlFor="floatingSelect">Filter</label>
             </div>
           </Col>
-          <Col xs={4} sm={3}>
+          <Col xs={3} sm={2}>
             <div className={`form-floating ${styles["custom-form-floating"]}`}>
               <select
                 className="form-select"
@@ -250,6 +294,42 @@ function Books() {
               )}
             </button>
           </Col>
+          <Col
+            xs={4}
+            sm={3}
+            className="d-flex justify-content-end align-items-center"
+          >
+            {!bulkDeleteMode && (
+              <button
+                type="button"
+                className={`btn btn-sm btn-outline-danger`}
+                onClick={handleBulkDeleteSetup}
+                aria-label="Bulk Delete Setup"
+              >
+                Bulk Delete
+              </button>
+            )}
+            {bulkDeleteMode && (
+              <>
+                <button
+                  type="button"
+                  className={`btn btn-sm btn-outline-danger`}
+                  onClick={handleBulkDelete}
+                  aria-label="Bulk Delete"
+                >
+                  Delete
+                </button>
+                <button
+                  type="button"
+                  className={`btn btn-sm btn-outline-secondary ms-1`}
+                  onClick={handleBulkDeleteCancel}
+                  aria-label="Bulk Delete Cancel"
+                >
+                  Cancel
+                </button>
+              </>
+            )}
+          </Col>
         </Row>
         <Row>
           {displayedBooks.map((book: BookWithBookshelvesInterface) => (
@@ -257,9 +337,23 @@ function Books() {
               xs={12}
               md={6}
               xl={4}
-              className="mt-3 mb-3"
+              className="mt-3 mb-3 position-relative"
               key={`col-${book.id}`}
             >
+              {bulkDeleteMode && (
+                <div
+                  className={`${styles["bulk-delete-overlay"]} ${selectedBooksForDeletion.includes(book.id) ? styles["bulk-delete-selected"] : ""}`}
+                  onClick={() => toggleBookForDeletion(book.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      toggleBookForDeletion(book.id);
+                    }
+                  }}
+                  role="button"
+                  tabIndex={0}
+                  aria-pressed={selectedBooksForDeletion.includes(book.id)}
+                ></div>
+              )}
               <Book book={book} preview={true} key={book.id} />
             </Col>
           ))}

--- a/frontend/src/components/books/css/Books.module.scss
+++ b/frontend/src/components/books/css/Books.module.scss
@@ -3,3 +3,23 @@
 
 @include customFormFloatingSelect();
 @include customFormFloatingLabel();
+
+.bulk-delete-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 10; // Ensure it's above the book content
+  cursor: pointer;
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.bulk-delete-overlay:hover {
+  background-color: rgba(212, 21, 21, 0.1);
+}
+
+.bulk-delete-overlay.bulk-delete-selected,
+.bulk-delete-overlay:hover.bulk-delete-selected {
+  background-color: rgba(212, 21, 21, 0.3);
+}

--- a/frontend/src/services/books.ts
+++ b/frontend/src/services/books.ts
@@ -48,6 +48,16 @@ export const DeleteBook = async (id: number): Promise<boolean> => {
   });
 };
 
+export const BulkDeleteBooks = async (book_ids: number[]): Promise<boolean> => {
+  return await Base(`/books/bulk`, {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ book_ids: book_ids }),
+  });
+};
+
 export const SearchBookByTitle = async (
   title: string
 ): Promise<WorkInterface[] | boolean> => {


### PR DESCRIPTION
There may be additional bulk actions we will want, but one that I noticed being a pain point was deleting multiple books at once from the Books page.

This is now done. The user can enter a `bulk book deletion mode` which nullifies interaction with individual Books, and allows for selection of multiple books, and then deletion with confirmation.

Closes #60 