### PR TITLE
Fix Star Rating Change on Books Page

### DIFF
--- a/frontend/src/components/books/Book.tsx
+++ b/frontend/src/components/books/Book.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState, useCallback, useRef } from "react";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import { useParams, useNavigate, NavLink } from "react-router-dom";
@@ -33,6 +33,10 @@ function Book({ book, preview }: BookProps) {
   const [readStartDate, setReadStartDate] = useState<Date | null>(null);
   const [readEndDate, setReadEndDate] = useState<Date | null>(null);
   const reviewPlaceholder = "Share your thoughts on this book ...";
+  // This is for tracking whether or not we've rendered the Book already
+  // when loaded from the Books component. We want to prevent unnecessarily
+  // re-setting the current book below, which can overwrite our state
+  const hasRenderedFromParent = useRef(false);
   const navigate = useNavigate();
 
   // From /books/{id}
@@ -40,10 +44,13 @@ function Book({ book, preview }: BookProps) {
 
   const initialize = useCallback(async () => {
     try {
-      if (bookProp) {
+      if (bookProp && !hasRenderedFromParent.current) {
         setCurrentBook(bookProp);
         setBookIdNumeric(bookProp.id);
         setBookIdString(bookProp.id.toString());
+        // Track the fact that we have rendered this component
+        // We don't want to overwrite our currentBook from the parent again
+        hasRenderedFromParent.current = true;
       }
       if (!currentBook && id) {
         setBookIdNumeric(parseInt(id));


### PR DESCRIPTION
When navigating to a Book, the Book component would load, and fetch its resource from the API based on Book id.

When a star rating was selected, the API was updated, and the correct, new star rating stayed in place visually on the page.

This was NOT happening when we were on the Books page and all Book components were loading in a loop, in preview mode.

It turns out that what was happening was this:

1. The Books component would load, fetching all books from the API
2. The Books component rendered individual Book components, and passed the entire book object to the Book component. This was done to save unnecessary calls to the API for all Book components, as we already had all the book data.
3. The individual Book components then had internal state, and the user could, in our case, update the star rating.
4. However, when the user made this selection, the parent Books component would re-render, and re-pass the 'book' resource into the Book component. This would override our Book component's internal state and re-set the book to its original state from when the Books component fetched all books

So the solution is to essentially track whether or not we've already rendered our Book component, triggered by the Books component, and if we have, we don't update the current book again with data passed in from the parent. This maintains our internal state and any changes made, such as updating star ratings.

Closes #84 
