### PR TITLE
Prevent Resubmission of forms

### DIFF
--- a/frontend/src/components/books/CreateBook.tsx
+++ b/frontend/src/components/books/CreateBook.tsx
@@ -26,6 +26,7 @@ function CreateBook() {
     []
   );
   const [selectedBook, setSelectedBook] = useState<number | null>(null);
+  const [creating, setCreating] = useState(false);
   const navigate = useNavigate();
 
   const API_BASE_URL = process.env.REACT_APP_API_URL || "";
@@ -90,6 +91,8 @@ function CreateBook() {
   };
 
   const handleCreate = async () => {
+    // We are in the process of creating. Disable the 'Create' button
+    setCreating(true);
     const json_olids = JSON.stringify(olids);
     const filteredBookData: Partial<CreateOrUpdateBookInterface> = {
       read_status: "not_read",
@@ -103,6 +106,7 @@ function CreateBook() {
     const response: boolean = await CreateBookService(filteredBookData);
     if (!response) {
       // A message to the user may be warranted here
+      setCreating(false);
       return false;
     }
     setTitle(null);
@@ -230,8 +234,19 @@ function CreateBook() {
                 type="button"
                 className="btn btn-primary"
                 onClick={handleCreateClick}
+                disabled={creating}
               >
-                Create
+                {creating && (
+                  <>
+                    <span
+                      className="spinner-border spinner-border-sm me-1"
+                      role="status"
+                      aria-hidden="true"
+                    ></span>
+                    Creating...
+                  </>
+                )}
+                {!creating && <span>Create</span>}
               </button>
             </Col>
           </Row>

--- a/frontend/src/components/bookshelves/CreateBookshelf.tsx
+++ b/frontend/src/components/bookshelves/CreateBookshelf.tsx
@@ -11,9 +11,12 @@ function CreateBookshelf() {
   const [description, setDescription] = useState("");
   const sort_key = "id";
   const sort_direction = "ascending";
+  const [creating, setCreating] = useState(false);
   const navigate = useNavigate();
 
   const handleSubmit = async () => {
+    // We are in the process of creating. Disable the 'Create' button
+    setCreating(true);
     const bookshelfData: CreateOrUpdateBookshelfInterface = {
       title,
       description,
@@ -24,11 +27,12 @@ function CreateBookshelf() {
     if (!response) {
       // A message to the user may be warranted here
       // Especially if we are going to prevent navigation
+      setCreating(false);
       return false;
     }
     setTitle("");
     setDescription("");
-    navigate(`/`);
+    // navigate(`/`);
   };
 
   const handleSubmitClick = (event: React.FormEvent<HTMLFormElement>) => {
@@ -70,8 +74,22 @@ function CreateBookshelf() {
                 onChange={(e) => setDescription(e.target.value)}
               />
             </div>
-            <button type="submit" className="btn btn-primary">
-              Create
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={creating}
+            >
+              {creating && (
+                <>
+                  <span
+                    className="spinner-border spinner-border-sm me-1"
+                    role="status"
+                    aria-hidden="true"
+                  ></span>
+                  Creating...
+                </>
+              )}
+              {!creating && <span>Create</span>}
             </button>
           </form>
         </Col>


### PR DESCRIPTION
Add a 'creating' state for when the user presses 'Create' for either a bookshelf or a book. This disables the button and indicates that we are in the process of creating. This is done to prevent duplicate submissions.

Closes #85 