### PR TITLE
Better lazy loading image handling

### DIFF
--- a/frontend/src/components/bookshelves/Bookshelf.tsx
+++ b/frontend/src/components/bookshelves/Bookshelf.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import Container from "react-bootstrap/Container";
@@ -13,6 +13,7 @@ import {
   DeleteBookFromBookshelf,
   UpdateBookshelf,
 } from "../../services/bookshelves";
+import useLazyLoad from "../../hooks/useLazyLoad";
 import LazyImage from "../common/LazyLoadImage";
 import {
   BookInterface,
@@ -50,6 +51,8 @@ function Bookshelf({ bookshelfId, preview }: BookshelfProps) {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const placeholderImageText = "No Cover Image Selected";
   const navigate = useNavigate();
+  const lazyLoadContainerRef = useRef<HTMLDivElement>(null);
+  const { observe, visibleImages } = useLazyLoad(lazyLoadContainerRef);
 
   const fetchBookshelf = useCallback(async () => {
     try {
@@ -405,7 +408,7 @@ function Bookshelf({ bookshelfId, preview }: BookshelfProps) {
         <Modal.Header closeButton>
           <Modal.Title>Choose one or more book to add</Modal.Title>
         </Modal.Header>
-        <Modal.Body>
+        <Modal.Body ref={lazyLoadContainerRef}>
           <Container>
             <Row>
               {booksThatCanBeAdded.map((book) => (
@@ -428,7 +431,8 @@ function Bookshelf({ bookshelfId, preview }: BookshelfProps) {
                     }
                     alt={`${book.title}: Book Cover`}
                     style={{ maxWidth: "100%", maxHeight: "100%" }}
-                    rootElement={document.querySelector(".modal-content")}
+                    observe={observe}
+                    visibleImages={visibleImages}
                   ></LazyImage>
                 </Col>
               ))}

--- a/frontend/src/components/common/LazyLoadImage.tsx
+++ b/frontend/src/components/common/LazyLoadImage.tsx
@@ -5,57 +5,33 @@ const LazyImage = ({
   alt,
   elementClass,
   style,
-  rootElement,
+  observe,
+  visibleImages,
+  onLoad,
 }: {
   src: string;
   alt: string;
   elementClass?: string;
   style: React.CSSProperties;
-  rootElement: HTMLElement | null;
+  observe: (el: Element | null) => void | null | undefined;
+  visibleImages: Set<string>;
+  onLoad?: (event: React.SyntheticEvent<HTMLImageElement>) => void;
 }) => {
   const imgRef = useRef<HTMLImageElement>(null);
 
   useEffect(() => {
-    const currentImgRef = imgRef.current;
-
-    if (!currentImgRef) {
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting && imgRef.current) {
-            imgRef.current.src = src;
-            observer.unobserve(entry.target);
-          }
-        });
-      },
-      {
-        root: rootElement || null,
-        threshold: 0.1,
-        rootMargin: "0px 0px 50px 0px",
-      }
-    );
-
-    if (currentImgRef) {
-      observer.observe(currentImgRef);
-    }
-  }, [src, rootElement]);
-
-  if (!rootElement) {
-    console.log("Could not find root element");
-    return <></>;
-  }
+    observe(imgRef.current);
+  }, [observe]);
 
   return (
     <img
       ref={imgRef}
+      src={visibleImages.has(src) ? src : ""}
       data-src={src}
       alt={alt}
-      loading="lazy"
       className={elementClass}
       style={style}
+      onLoad={onLoad}
     />
   );
 };

--- a/frontend/src/hooks/useLazyLoad.ts
+++ b/frontend/src/hooks/useLazyLoad.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState, useRef } from "react";
+
+const useLazyLoad = (rootRef: React.RefObject<HTMLElement>) => {
+  const [visibleImages, setVisibleImages] = useState<Set<string>>(new Set());
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  if (!rootRef) {
+    console.log("Could not find root element");
+  }
+
+  useEffect(() => {
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        setVisibleImages((prev) => {
+          const updated = new Set(prev);
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              const target = entry.target as HTMLElement;
+              updated.add(target.dataset.src as string);
+            }
+          });
+          return updated;
+        });
+      },
+      { root: rootRef.current, threshold: 0.1, rootMargin: "0px 0px 50px 0px" }
+    );
+
+    return () => observerRef.current?.disconnect();
+  }, []);
+
+  return {
+    observe: (el: Element | null) => el && observerRef.current?.observe(el),
+    visibleImages,
+  };
+};
+
+export default useLazyLoad;


### PR DESCRIPTION
Primarily changing the way we handle observing image visibility. One observer instead of many for performance reasons. Using this new method in our Book Cover selection, ensuring only visible images load.

Closes #136 