### PR TITLE
Indicating Editability

### DIFF
--- a/frontend/src/components/books/Book.tsx
+++ b/frontend/src/components/books/Book.tsx
@@ -531,6 +531,7 @@ function Book({ book, preview }: BookProps) {
             >
               <h1
                 id="book-title"
+                className={`${styles["book-metadata-content-editable"]}`}
                 style={{
                   fontSize: `${determineTitleFontSize(currentBook?.title.length as number)}rem`,
                   fontWeight: 300,
@@ -699,7 +700,10 @@ function Book({ book, preview }: BookProps) {
                 suppressContentEditableWarning={true}
                 data-testid="book-author-content-editable"
               >
-                <h3 id="book-author" className="display-6">
+                <h3
+                  id="book-author"
+                  className={`display-6 ${styles["book-metadata-content-editable"]}`}
+                >
                   {currentBook?.author}
                 </h3>
               </div>
@@ -729,7 +733,12 @@ function Book({ book, preview }: BookProps) {
                 suppressContentEditableWarning={true}
                 data-testid="book-year-content-editable"
               >
-                <h5 id="book-year">{currentBook?.year}</h5>
+                <h5
+                  id="book-year"
+                  className={`${styles["book-metadata-content-editable"]}`}
+                >
+                  {currentBook?.year}
+                </h5>
               </div>
             )}
           </Row>

--- a/frontend/src/components/books/css/Book.module.scss
+++ b/frontend/src/components/books/css/Book.module.scss
@@ -91,3 +91,11 @@
 .title-preview {
   font-weight: 700;
 }
+.book-metadata-content-editable {
+  cursor: text;
+  border-bottom: 3px solid transparent; /* Keeps space, but invisible initially */
+  transition: border-color 0.2s ease-in-out;
+}
+.book-metadata-content-editable:hover {
+  border-color: gray;
+}


### PR DESCRIPTION
Time will tell if this user experience is better, worse, or the same. Might be tweaked in the future, but I think adding a bottom border when hovering over editable text, in combination with the cursor, gives a decent indication that the text is editable.

It does make me think that maybe title and description of Bookshelves should work the same way, as opposed to an 'Update' button that drops the user into a form. 

Closes #154 